### PR TITLE
[✨ 개선] Chatbot 사용 가능 상태 표시 API 추가

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/src/main/java/baekgwa/blogserver/domain/ai/controller/AiController.java
+++ b/src/main/java/baekgwa/blogserver/domain/ai/controller/AiController.java
@@ -1,5 +1,6 @@
 package baekgwa.blogserver.domain.ai.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import baekgwa.blogserver.domain.ai.dto.AiRequest;
+import baekgwa.blogserver.domain.ai.dto.AiResponse;
 import baekgwa.blogserver.domain.ai.dto.EmbeddingPostRequest;
 import baekgwa.blogserver.domain.ai.service.AiService;
 import baekgwa.blogserver.global.response.BaseResponse;
@@ -52,5 +54,12 @@ public class AiController {
 	) {
 		aiService.embeddingPosts(request);
 		return BaseResponse.success(SuccessCode.EMBEDDING_POST_SUCCESS);
+	}
+
+	@GetMapping("/health")
+	@Operation(summary = "백과 블로그 Chatbot 사용 가능 상태 확인")
+	public BaseResponse<AiResponse.AiHealthCheck> chatbotHealthCheck() {
+		AiResponse.AiHealthCheck response = aiService.healthCheck();
+		return BaseResponse.success(SuccessCode.ENABLE_CHAT_BOT, response);
 	}
 }

--- a/src/main/java/baekgwa/blogserver/domain/ai/controller/AiController.java
+++ b/src/main/java/baekgwa/blogserver/domain/ai/controller/AiController.java
@@ -9,6 +9,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import baekgwa.blogserver.domain.ai.dto.AiRequest;
 import baekgwa.blogserver.domain.ai.dto.EmbeddingPostRequest;
 import baekgwa.blogserver.domain.ai.service.AiService;
+import baekgwa.blogserver.global.response.BaseResponse;
+import baekgwa.blogserver.global.response.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -45,9 +47,10 @@ public class AiController {
 
 	@PostMapping("/post/embedding")
 	@Operation(summary = "수동 post embedding 후, vector db 에 저장")
-	public void embeddingPost(
+	public BaseResponse<Void> embeddingPost(
 		@RequestBody EmbeddingPostRequest request
 	) {
 		aiService.embeddingPosts(request);
+		return BaseResponse.success(SuccessCode.EMBEDDING_POST_SUCCESS);
 	}
 }

--- a/src/main/java/baekgwa/blogserver/domain/ai/dto/AiResponse.java
+++ b/src/main/java/baekgwa/blogserver/domain/ai/dto/AiResponse.java
@@ -1,0 +1,38 @@
+package baekgwa.blogserver.domain.ai.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * PackageName : baekgwa.blogserver.domain.ai.dto
+ * FileName    : AiResponse
+ * Author      : Baekgwa
+ * Date        : 25. 11. 24.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 25. 11. 24.     Baekgwa               Initial creation
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AiResponse {
+
+	@Getter
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
+	public static class AiHealthCheck {
+		private HealthStatus database;
+		private HealthStatus llm;
+		private boolean isAvailable;
+	}
+
+	public enum HealthStatus {
+		UP,
+		DOWN,
+		UNKNOWN
+	}
+}

--- a/src/main/java/baekgwa/blogserver/domain/ai/service/AiService.java
+++ b/src/main/java/baekgwa/blogserver/domain/ai/service/AiService.java
@@ -12,6 +12,7 @@ import java.util.concurrent.Executor;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -66,6 +67,7 @@ public class AiService {
 
 	private final Executor taskExecutor;
 	private final RestClient elasticSearchRestClient;
+	@Qualifier("openAiRestTemplate")
 	private final RestTemplate openAiRestTemplate;
 
 	/**

--- a/src/main/java/baekgwa/blogserver/domain/ai/service/AiService.java
+++ b/src/main/java/baekgwa/blogserver/domain/ai/service/AiService.java
@@ -6,12 +6,20 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import baekgwa.blogserver.domain.ai.dto.AiRequest;
+import baekgwa.blogserver.domain.ai.dto.AiResponse;
 import baekgwa.blogserver.domain.ai.dto.EmbeddingPostRequest;
 import baekgwa.blogserver.infra.embedding.service.EmbeddingService;
 import baekgwa.blogserver.model.embedding.entity.EmbeddingFailureEntity;
@@ -55,6 +63,10 @@ public class AiService {
 	private final PostTagRepository postTagRepository;
 	private final EmbeddingFailureRepository embeddingFailureRepository;
 	private final StreamingChatModel streamingChatModel;
+
+	private final Executor taskExecutor;
+	private final RestClient elasticSearchRestClient;
+	private final RestTemplate openAiRestTemplate;
 
 	/**
 	 * 수동으로, 특정 포스팅 임베딩 후 db 저장
@@ -236,5 +248,61 @@ public class AiService {
 				.append(segment.text()).append("\n\n");
 		}
 		return sb.toString();
+	}
+
+	public AiResponse.AiHealthCheck healthCheck() {
+		// 1. elk connection check
+		CompletableFuture<AiResponse.HealthStatus> dbFuture = CompletableFuture.supplyAsync(
+			this::checkElkConnection,
+			taskExecutor
+		);
+
+		// 2. llm connection check
+		CompletableFuture<AiResponse.HealthStatus> llmFuture = CompletableFuture.supplyAsync(
+			this::checkOpenAiConnection,
+			taskExecutor
+		);
+
+		AiResponse.HealthStatus dbStatus = dbFuture.join();
+		AiResponse.HealthStatus llmStatus = llmFuture.join();
+		boolean isAvailable =
+			(dbStatus == AiResponse.HealthStatus.UP) && (llmStatus == AiResponse.HealthStatus.UP);
+
+		return AiResponse.AiHealthCheck.builder()
+			.database(dbStatus)
+			.llm(llmStatus)
+			.isAvailable(isAvailable)
+			.build();
+	}
+
+	private AiResponse.HealthStatus checkElkConnection() {
+		try {
+			Response response = elasticSearchRestClient.performRequest(new Request("HEAD", "/"));
+
+			log.debug("[HealthCheck] VectorDB Connection Success");
+
+			return response.getStatusLine().getStatusCode() == 200 ?
+				AiResponse.HealthStatus.UP :
+				AiResponse.HealthStatus.DOWN;
+		} catch (Exception e) {
+			log.debug("[HealthCheck] ELK Connection Failed: {}", e.getMessage());
+			return AiResponse.HealthStatus.DOWN;
+		}
+	}
+
+	private AiResponse.HealthStatus checkOpenAiConnection() {
+		try {
+			// models 를 호출해서 연결이 가능한지 확인. 이게 제일 저렴
+			ResponseEntity<String> response = openAiRestTemplate.getForEntity("/models", String.class);
+
+			log.debug("[HealthCheck] OpenAI Connection Success");
+
+			return response.getStatusCode().is2xxSuccessful() ?
+				AiResponse.HealthStatus.UP :
+				AiResponse.HealthStatus.DOWN;
+		} catch (Exception e) {
+			log.debug("[HealthCheck] OpenAI Connection Failed: {}", e.getMessage());
+			return AiResponse.HealthStatus.DOWN;
+		}
 	}
 }

--- a/src/main/java/baekgwa/blogserver/global/config/AsyncConfig.java
+++ b/src/main/java/baekgwa/blogserver/global/config/AsyncConfig.java
@@ -2,6 +2,7 @@ package baekgwa.blogserver.global.config;
 
 import java.util.concurrent.Executor;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -22,8 +23,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @Configuration
 public class AsyncConfig implements AsyncConfigurer {
 
-	@Override
-	public Executor getAsyncExecutor() {
+	@Bean(name = "taskExecutor")
+	public Executor taskExecutor() {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 		executor.setCorePoolSize(5);
 		executor.setMaxPoolSize(10);
@@ -33,5 +34,10 @@ public class AsyncConfig implements AsyncConfigurer {
 		executor.setAwaitTerminationSeconds(60);
 		executor.initialize();
 		return executor;
+	}
+
+	@Override
+	public Executor getAsyncExecutor() {
+		return taskExecutor();
 	}
 }

--- a/src/main/java/baekgwa/blogserver/global/config/ElasticsearchConfig.java
+++ b/src/main/java/baekgwa/blogserver/global/config/ElasticsearchConfig.java
@@ -41,7 +41,18 @@ public class ElasticsearchConfig {
 	private final ElasticSearchProperties elasticSearchProperties;
 
 	@Bean
-	public EmbeddingStore<TextSegment> embeddingStore() throws IOException {
+	public EmbeddingStore<TextSegment> embeddingStore(RestClient restClient) throws IOException {
+		ensureIndexExists(restClient, elasticSearchProperties.getEmbeddingIndexName());
+
+		return ElasticsearchEmbeddingStore
+			.builder()
+			.indexName(elasticSearchProperties.getEmbeddingIndexName())
+			.restClient(restClient)
+			.build();
+	}
+
+	@Bean
+	public RestClient elasticsearchRestClient() {
 		log.info("🚀 Loading Standard Elasticsearch RestClient...");
 
 		final BasicCredentialsProvider credential = new BasicCredentialsProvider();
@@ -52,18 +63,10 @@ public class ElasticsearchConfig {
 			)
 		);
 
-		RestClient restClient = RestClient
+		return RestClient
 			.builder(HttpHost.create(elasticSearchProperties.getUrl()))
 			.setHttpClientConfigCallback(
 				httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credential))
-			.build();
-
-		ensureIndexExists(restClient, elasticSearchProperties.getEmbeddingIndexName());
-
-		return ElasticsearchEmbeddingStore
-			.builder()
-			.indexName(elasticSearchProperties.getEmbeddingIndexName())
-			.restClient(restClient)
 			.build();
 	}
 

--- a/src/main/java/baekgwa/blogserver/global/config/OpenAiConfig.java
+++ b/src/main/java/baekgwa/blogserver/global/config/OpenAiConfig.java
@@ -1,8 +1,12 @@
 package baekgwa.blogserver.global.config;
 
+import java.time.Duration;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.web.client.RestTemplate;
 
 import baekgwa.blogserver.global.environment.OpenAiProperties;
 import dev.langchain4j.model.chat.StreamingChatModel;
@@ -44,6 +48,16 @@ public class OpenAiConfig {
 			.builder()
 			.apiKey(openAiProperties.getApiKey())
 			.modelName(openAiProperties.getLlmModelName())
+			.build();
+	}
+
+	@Bean
+	public RestTemplate openAiRestTemplate(RestTemplateBuilder builder) {
+		return builder
+			.rootUri("https://api.openai.com/v1")
+			.defaultHeader("Authorization", "Bearer " + openAiProperties.getApiKey())
+			.connectTimeout(Duration.ofSeconds(3))
+			.readTimeout(Duration.ofSeconds(3))
 			.build();
 	}
 }

--- a/src/main/java/baekgwa/blogserver/global/config/OpenAiConfig.java
+++ b/src/main/java/baekgwa/blogserver/global/config/OpenAiConfig.java
@@ -51,7 +51,7 @@ public class OpenAiConfig {
 			.build();
 	}
 
-	@Bean
+	@Bean(name = "openAiRestTemplate")
 	public RestTemplate openAiRestTemplate(RestTemplateBuilder builder) {
 		return builder
 			.rootUri("https://api.openai.com/v1")

--- a/src/main/java/baekgwa/blogserver/global/response/SuccessCode.java
+++ b/src/main/java/baekgwa/blogserver/global/response/SuccessCode.java
@@ -50,6 +50,7 @@ public enum SuccessCode {
 
 	//AI
 	EMBEDDING_POST_SUCCESS(HttpStatus.CREATED, "게시글 임베딩 성공"),
+	ENABLE_CHAT_BOT(HttpStatus.OK, "Chatbot health check 성공"),
 
 	//Common
 	REQUEST_SUCCESS(HttpStatus.OK, "요청 응답 성공.");

--- a/src/main/java/baekgwa/blogserver/global/response/SuccessCode.java
+++ b/src/main/java/baekgwa/blogserver/global/response/SuccessCode.java
@@ -48,6 +48,9 @@ public enum SuccessCode {
 	MODIFY_STACK_SUCCESS(HttpStatus.OK, "스택 내용 수정 성공"),
 	GET_MODIFY_STACK_INFO_SUCCESS(HttpStatus.OK, "스택 내용 조회 성공"),
 
+	//AI
+	EMBEDDING_POST_SUCCESS(HttpStatus.CREATED, "게시글 임베딩 성공"),
+
 	//Common
 	REQUEST_SUCCESS(HttpStatus.OK, "요청 응답 성공.");
 

--- a/src/main/java/baekgwa/blogserver/infra/embedding/service/EmbeddingOpenAiService.java
+++ b/src/main/java/baekgwa/blogserver/infra/embedding/service/EmbeddingOpenAiService.java
@@ -104,8 +104,7 @@ public class EmbeddingOpenAiService implements EmbeddingService {
 
 			// 5. Vector DB(Elasticsearch) 저장
 			embeddingStore.addAll(embeddingResponse.content(), textSegmentList);
-			log.debug("Successfully embedded and stored postId={}", post.getId());
-
+			log.info("Successfully embedded and stored postId={}, title={}", post.getId(), post.getTitle());
 		} catch (Exception e) {
 			log.warn("Embedding failed for postId={}: {}", post.getId(), e.getMessage());
 			throw e;

--- a/src/test/java/baekgwa/blogserver/integration/SpringBootTestSupporter.java
+++ b/src/test/java/baekgwa/blogserver/integration/SpringBootTestSupporter.java
@@ -1,11 +1,13 @@
 package baekgwa.blogserver.integration;
 
+import org.elasticsearch.client.RestClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -131,6 +133,10 @@ public abstract class SpringBootTestSupporter {
 	protected EmbeddingService embeddingService;
 	@MockitoBean
 	protected ViewCountStore viewCountStore;
+	@MockitoBean
+	protected RestClient restClient;
+	@MockitoBean(name = "openAiRestTemplate")
+	protected RestTemplate openAiRestTemplate;
 
 	/**
 	 * Static variable


### PR DESCRIPTION
<!-- 제목 : [분류] : 제목 -->
<!-- 분류 = 이슈 분류  -->
## 👇 개요
<!-- 간단한 개요  -->
- #37 
---

## 🔨 작업 내용

- [x] Chatbot 사용 가능 상태를 응답해줄 API 생성
- [x] ELK Connection 확인을 위한, `RestClient` Bean 등록 
- [x] Open AI Connection 확인을 위한, `RestTemplate` Bean 등록

---

## 🧪 확인 사항

- [x] 빌드 정상 작동
- [x] 주요 기능 정상 동작
