### PR TITLE
[✨ 개선] Query 튜닝

### DIFF
--- a/src/main/java/baekgwa/blogserver/domain/category/dto/CategoryResponse.java
+++ b/src/main/java/baekgwa/blogserver/domain/category/dto/CategoryResponse.java
@@ -31,13 +31,13 @@ public class CategoryResponse {
 		private final Long id;
 		private final Long count;
 
-		public static List<CategoryList> from(List<CategoryPostCount> categoryEntityList) {
-			return categoryEntityList
+		public static List<CategoryList> from(List<CategoryPostCount> projectionList) {
+			return projectionList
 				.stream()
 				.map(data -> CategoryList
 					.builder()
-					.name(data.category().getName())
-					.id(data.category().getId())
+					.id(data.id())
+					.name(data.name())
 					.count(data.postCount())
 					.build())
 				.toList();

--- a/src/main/java/baekgwa/blogserver/domain/post/dto/PostResponse.java
+++ b/src/main/java/baekgwa/blogserver/domain/post/dto/PostResponse.java
@@ -3,6 +3,8 @@ package baekgwa.blogserver.domain.post.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.querydsl.core.annotations.QueryProjection;
+
 import baekgwa.blogserver.model.post.post.entity.PostEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -70,8 +72,6 @@ public class PostResponse {
 	}
 
 	@Getter
-	@Builder(access = AccessLevel.PROTECTED)
-	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class GetPostResponse {
 		private final Long id;
 		private final String title;
@@ -79,25 +79,29 @@ public class PostResponse {
 		private final String thumbnailImage;
 		private final String slug;
 		private final Integer viewCount;
-		private final List<String> tagList;
+		private List<String> tagList; // final 제거 (나중에 주입)
 		private final String category;
 		private final LocalDateTime createdAt;
 		private final LocalDateTime modifiedAt;
 
-		public static GetPostResponse of(PostEntity post, List<String> tagList) {
-			return GetPostResponse
-				.builder()
-				.id(post.getId())
-				.title(post.getTitle())
-				.description(post.getDescription())
-				.thumbnailImage(post.getThumbnailImage())
-				.slug(post.getSlug())
-				.viewCount(post.getViewCount())
-				.tagList(tagList)
-				.category(post.getCategory().getName())
-				.createdAt(post.getCreatedAt())
-				.modifiedAt(post.getModifiedAt())
-				.build();
+		@QueryProjection // Q클래스 생성을 위해 추가
+		public GetPostResponse(Long id, String title, String description, String thumbnailImage,
+			String slug, Integer viewCount, String category,
+			LocalDateTime createdAt, LocalDateTime modifiedAt) {
+			this.id = id;
+			this.title = title;
+			this.description = description;
+			this.thumbnailImage = thumbnailImage;
+			this.slug = slug;
+			this.viewCount = viewCount;
+			this.category = category;
+			this.createdAt = createdAt;
+			this.modifiedAt = modifiedAt;
+		}
+
+		// 태그 리스트를 나중에 넣어주기 위한 메서드
+		public void updateTagList(List<String> tagList) {
+			this.tagList = tagList;
 		}
 	}
 }

--- a/src/main/java/baekgwa/blogserver/domain/stack/dto/StackResponse.java
+++ b/src/main/java/baekgwa/blogserver/domain/stack/dto/StackResponse.java
@@ -174,8 +174,8 @@ public class StackResponse {
 				.slug(stackPost.getPost().getSlug())
 				.sequence(stackPost.getSequence())
 				.viewCount(stackPost.getPost().getViewCount())
-				.createdAt(stackPost.getCreatedAt())
-				.modifiedAt(stackPost.getModifiedAt())
+				.createdAt(stackPost.getPost().getCreatedAt())
+				.modifiedAt(stackPost.getPost().getModifiedAt())
 				.thumbnailImage(stackPost.getPost().getThumbnailImage())
 				.build();
 		}

--- a/src/main/java/baekgwa/blogserver/domain/stack/service/StackService.java
+++ b/src/main/java/baekgwa/blogserver/domain/stack/service/StackService.java
@@ -3,7 +3,6 @@ package baekgwa.blogserver.domain.stack.service;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -113,26 +112,13 @@ public class StackService {
 
 	@Transactional(readOnly = true)
 	public StackResponse.StackInfo getRelativeStackPostInfo(Long postId) {
-		// 1. Post id 유효성 검사
-		if (!postRepository.existsById(postId)) {
-			throw new GlobalException(ErrorCode.NOT_EXIST_POST);
-		}
+		StackPostEntity findStackPost = stackPostRepository.findByPostIdWithStack(postId)
+			.orElseThrow(() -> new GlobalException(ErrorCode.NOT_EXIST_POST));
 
-		// 1. 연결된 Stack 조회
-		Optional<StackPostEntity> opFindStackPost = stackPostRepository.findByPostId(postId);
-
-		// 2. 해당 글이 스택에 등록되어있지 않으면 빈값 return
-		if (opFindStackPost.isEmpty()) {
-			return null;
-		}
-
-		// 3. 연관된 스택 조회 후, 스택의 모든 포스트 조회
-		StackEntity findStack = opFindStackPost.get().getStack();
+		StackEntity findStack = findStackPost.getStack();
 		List<StackPostEntity> findStackPostList = stackPostRepository.findAllByStack(findStack);
 
-		// 4. dto 변환 및 return
-		List<StackResponse.StackPostInfo> stackPostInfoList = findStackPostList
-			.stream()
+		List<StackResponse.StackPostInfo> stackPostInfoList = findStackPostList.stream()
 			.map(StackResponse.StackPostInfo::of)
 			.sorted(Comparator.comparing(StackResponse.StackPostInfo::getSequence))
 			.toList();

--- a/src/main/java/baekgwa/blogserver/domain/stack/service/StackService.java
+++ b/src/main/java/baekgwa/blogserver/domain/stack/service/StackService.java
@@ -143,17 +143,14 @@ public class StackService {
 
 	@Transactional(readOnly = true)
 	public StackResponse.StackDetail getStackDetail(Long stackId) {
-		// 1. 스택 조회
-		StackEntity findStack = stackRepository.findById(stackId).orElseThrow(
+		StackEntity findStack = stackRepository.findWithCategoryById(stackId).orElseThrow(
 			() -> new GlobalException(ErrorCode.NOTFOUND_STACK));
 
-		// 2. 스택에 할당된 글목록 조회
 		List<StackPostEntity> findStackPostList = stackPostRepository.findAllByStack(findStack);
 		List<StackResponse.StackPostInfo> stackPostInfoList = findStackPostList.stream()
 			.map(StackResponse.StackPostInfo::of)
 			.toList();
 
-		// 3. dto return
 		return StackResponse.StackDetail.of(findStack, stackPostInfoList);
 	}
 

--- a/src/main/java/baekgwa/blogserver/domain/stack/service/StackService.java
+++ b/src/main/java/baekgwa/blogserver/domain/stack/service/StackService.java
@@ -3,6 +3,7 @@ package baekgwa.blogserver.domain.stack.service;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -112,10 +113,10 @@ public class StackService {
 
 	@Transactional(readOnly = true)
 	public StackResponse.StackInfo getRelativeStackPostInfo(Long postId) {
-		StackPostEntity findStackPost = stackPostRepository.findByPostIdWithStack(postId)
-			.orElseThrow(() -> new GlobalException(ErrorCode.NOT_EXIST_POST));
+		Optional<StackPostEntity> opFindStackPost = stackPostRepository.findByPostIdWithStack(postId);
+		if(opFindStackPost.isEmpty()) return null;
 
-		StackEntity findStack = findStackPost.getStack();
+		StackEntity findStack = opFindStackPost.get().getStack();
 		List<StackPostEntity> findStackPostList = stackPostRepository.findAllByStack(findStack);
 
 		List<StackResponse.StackPostInfo> stackPostInfoList = findStackPostList.stream()

--- a/src/main/java/baekgwa/blogserver/model/category/projection/CategoryPostCount.java
+++ b/src/main/java/baekgwa/blogserver/model/category/projection/CategoryPostCount.java
@@ -1,7 +1,5 @@
 package baekgwa.blogserver.model.category.projection;
 
-import baekgwa.blogserver.model.category.entity.CategoryEntity;
-
 /**
  * PackageName : baekgwa.blogserver.model.category.projection
  * FileName    : CategoryPostCount
@@ -13,4 +11,9 @@ import baekgwa.blogserver.model.category.entity.CategoryEntity;
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-10-21     Baekgwa               Initial creation
  */
-public record CategoryPostCount(CategoryEntity category, Long postCount) {}
+public record CategoryPostCount(
+	Long id,
+	String name,
+	Long postCount
+) {
+}

--- a/src/main/java/baekgwa/blogserver/model/category/repository/CategoryRepository.java
+++ b/src/main/java/baekgwa/blogserver/model/category/repository/CategoryRepository.java
@@ -26,9 +26,10 @@ public interface CategoryRepository extends JpaRepository<CategoryEntity, Long> 
 
 	Optional<CategoryEntity> findByName(String name);
 
-	@Query("SELECT new baekgwa.blogserver.model.category.projection.CategoryPostCount(c, COUNT(p.id)) " +
-		"FROM CategoryEntity c LEFT JOIN PostEntity p ON c.id = p.category.id " +
-		"GROUP BY c.id " +
+	@Query("SELECT new baekgwa.blogserver.model.category.projection.CategoryPostCount(c.id, c.name, COUNT(p.id)) " +
+		"FROM CategoryEntity c " +
+		"LEFT JOIN PostEntity p ON c.id = p.category.id " +
+		"GROUP BY c.name " +
 		"ORDER BY c.name")
 	List<CategoryPostCount> findAllWithPostCount();
 }

--- a/src/main/java/baekgwa/blogserver/model/post/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/baekgwa/blogserver/model/post/post/repository/PostRepositoryImpl.java
@@ -20,6 +20,7 @@ import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import baekgwa.blogserver.domain.post.dto.PostResponse;
+import baekgwa.blogserver.domain.post.dto.QPostResponse_GetPostResponse;
 import baekgwa.blogserver.domain.post.type.PostListSort;
 import baekgwa.blogserver.model.post.post.entity.QPostEntity;
 import baekgwa.blogserver.model.post.tag.entity.QPostTagEntity;
@@ -91,14 +92,26 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
 		// 5. 전체 데이터 조회. 후, dto 변환
 		List<PostResponse.GetPostResponse> findData = queryFactory
-			.selectFrom(postEntity)
+			.select(new QPostResponse_GetPostResponse(
+				postEntity.id,
+				postEntity.title,
+				postEntity.description,
+				postEntity.thumbnailImage,
+				postEntity.slug,
+				postEntity.viewCount,
+				postEntity.category.name,
+				postEntity.createdAt,
+				postEntity.modifiedAt
+			))
+			.from(postEntity)
+			.join(postEntity.category)
 			.where(postEntity.id.in(postIdList))
 			.orderBy(orderSpecifier)
-			.fetch()
-			.stream()
-			.map(post -> PostResponse.GetPostResponse.of(
-				post, tagMap.getOrDefault(post.getId(), List.of())))
-			.toList();
+			.fetch();
+
+		findData.forEach(dto ->
+			dto.updateTagList(tagMap.getOrDefault(dto.getId(), List.of()))
+		);
 
 		// 6. 전체 item 개수 조회
 		Long totalCount = queryFactory

--- a/src/main/java/baekgwa/blogserver/model/stack/post/repository/StackPostRepository.java
+++ b/src/main/java/baekgwa/blogserver/model/stack/post/repository/StackPostRepository.java
@@ -23,17 +23,14 @@ import baekgwa.blogserver.model.stack.stack.entity.StackEntity;
  * 2025-10-22     Baekgwa               Initial creation
  */
 public interface StackPostRepository extends JpaRepository<StackPostEntity, Long> {
-	@Query("SELECT sp FROM StackPostEntity sp WHERE sp.post.id = :postId")
-	Optional<StackPostEntity> findByPostId(@Param(value = "postId") Long postId);
+	@Query("SELECT sp FROM StackPostEntity sp JOIN FETCH sp.stack WHERE sp.post.id = :postId")
+	Optional<StackPostEntity> findByPostIdWithStack(@Param("postId") Long postId);
 
 	@EntityGraph(attributePaths = {"post"})
 	List<StackPostEntity> findAllByStack(StackEntity findStack);
 
 	@Query("SELECT COUNT(sp) > 0 FROM StackPostEntity sp WHERE sp.post.id IN :postIdList")
 	boolean existsByPostIdIn(@Param("postIdList") List<Long> postIdList);
-
-	@Query("SELECT sp FROM StackPostEntity sp JOIN FETCH sp.stack s JOIN FETCH sp.post p")
-	List<StackPostEntity> findAllWithStackAndPost();
 
 	void deleteAllByStack(StackEntity stack);
 }

--- a/src/main/java/baekgwa/blogserver/model/stack/stack/repository/StackRepository.java
+++ b/src/main/java/baekgwa/blogserver/model/stack/stack/repository/StackRepository.java
@@ -1,7 +1,9 @@
 package baekgwa.blogserver.model.stack.stack.repository;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -30,4 +32,7 @@ public interface StackRepository extends JpaRepository<StackEntity, Long> {
 		"LEFT JOIN sp.post p " +
 		"GROUP BY s.id")
 	List<StackStatsDto> findStackStats();
+
+	@EntityGraph(attributePaths = {"category"})
+	Optional<StackEntity> findWithCategoryById(Long id);
 }

--- a/src/main/resources/db/migration/V2.2.0__update_post_tag_category_table.sql
+++ b/src/main/resources/db/migration/V2.2.0__update_post_tag_category_table.sql
@@ -1,0 +1,18 @@
+/**
+ * FileName    : V2.2.0__update_post_tag_category_table.sql
+ * Author      : Baekgwa
+ * Date        : 2025-11-08
+ * Description :
+ * =====================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 2025-11-08     Baekgwa             성능 최적화 목표, 커버링 인덱스 및 일반 인덱스 추가 설정
+ */
+
+# 포스트 글 목록 페이징 시, 사용될 covering index 추가.
+# select pte1_0.post_id,te1_0.name from post_tag pte1_0 join tag te1_0 on pte1_0.tag_id=te1_0.id where pte1_0.post_id in (??,??);
+CREATE INDEX idx_post_tag_covering ON post_tag (post_id, tag_id);
+
+# 포스트 글 목록 페이징 시, Category 필터링을 위해 활용되기 때문에, index 처리
+# 이때, category name 은 유니크 하게 설정되는게 더 맞아, UNIQUE Index 로 처리
+ALTER TABLE `category` ADD UNIQUE INDEX `uk_category_name` (`name`);

--- a/src/test/java/baekgwa/blogserver/domain/stack/service/StackServiceTest.java
+++ b/src/test/java/baekgwa/blogserver/domain/stack/service/StackServiceTest.java
@@ -221,18 +221,6 @@ class StackServiceTest extends SpringBootTestSupporter {
 		assertThat(response).isNull();
 	}
 
-	@DisplayName("현재 입력받은 postId 가 포함된 스택(시리즈)의 목록을 조회합니다. 잘못된 글 id 라면 오류를 발생합니다.")
-	@Test
-	void getRelativeStackPostInfo3() {
-		// given
-
-		// when // then
-		assertThatThrownBy(() -> stackService.getRelativeStackPostInfo(1L))
-			.isInstanceOf(GlobalException.class)
-			.extracting("errorCode")
-			.isEqualTo(ErrorCode.NOT_EXIST_POST);
-	}
-
 	@DisplayName("현재 등록된 모든 스택(시리즈)의 정보를 return 합니다.")
 	@Test
 	void getAllStack1() {


### PR DESCRIPTION
<!-- 제목 : [분류] : 제목 -->
<!-- 분류 = 이슈 분류  -->
## 👇 개요
<!-- 간단한 개요  -->
- #50 
- 사용 빈도수가 많은 API 들의 Query 들을 분석해서 최적화 진행

---

## 🔨 작업 내용

- [x] 메인페이지, 페이징 쿼리 (목록 조회) 튜닝
  - [x] N+1, indexing 처리, covering indexing 처리
  - [x] 불필요 content data (html) 로딩 방지용 projection dto 변경
- [x] 카테고리 전체 조회 튜닝
  - [x] file-sort, temporary 처리
- [x] 연관 글 조회 튜닝
  - [x] N+1 해결 및 불필요 쿼리 합체
- [x] 스택 목록 조회 튜닝
  - [x] N+1 문제 해결
- [x] 스택 상세 조회 시, 데이터 불일치 버그 수정
---

## 🧪 확인 사항

- [x] 빌드 정상 작동
- [x] 주요 기능 정상 동작
