### PR TITLE
[✨ 개선] API 캐싱 처리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,11 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+// -parameters options 추가
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs.add("-parameters")
+}
+
 tasks.named('test') {
     useJUnitPlatform()
     finalizedBy 'jacocoTestReport'

--- a/src/main/java/baekgwa/blogserver/domain/category/dto/CategoryResponse.java
+++ b/src/main/java/baekgwa/blogserver/domain/category/dto/CategoryResponse.java
@@ -1,6 +1,7 @@
 package baekgwa.blogserver.domain.category.dto;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import baekgwa.blogserver.model.category.projection.CategoryPostCount;
 import lombok.AccessLevel;
@@ -8,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * PackageName : baekgwa.blogserver.domain.category.dto
@@ -24,6 +26,7 @@ import lombok.NoArgsConstructor;
 public class CategoryResponse {
 
 	@Getter
+	@Jacksonized
 	@Builder(access = AccessLevel.PROTECTED)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class CategoryList {
@@ -40,7 +43,7 @@ public class CategoryResponse {
 					.name(data.name())
 					.count(data.postCount())
 					.build())
-				.toList();
+				.collect(Collectors.toList());
 		}
 	}
 }

--- a/src/main/java/baekgwa/blogserver/domain/category/service/CategoryService.java
+++ b/src/main/java/baekgwa/blogserver/domain/category/service/CategoryService.java
@@ -2,11 +2,14 @@ package baekgwa.blogserver.domain.category.service;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import baekgwa.blogserver.domain.category.dto.CategoryRequest;
 import baekgwa.blogserver.domain.category.dto.CategoryResponse;
+import baekgwa.blogserver.global.cache.CacheType;
 import baekgwa.blogserver.global.exception.GlobalException;
 import baekgwa.blogserver.global.response.ErrorCode;
 import baekgwa.blogserver.model.category.entity.CategoryEntity;
@@ -14,6 +17,7 @@ import baekgwa.blogserver.model.category.projection.CategoryPostCount;
 import baekgwa.blogserver.model.category.repository.CategoryRepository;
 import baekgwa.blogserver.model.post.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * PackageName : baekgwa.blogserver.domain.category.service
@@ -26,46 +30,46 @@ import lombok.RequiredArgsConstructor;
  * ---------------------------------------------------------------------------------------------------------------------
  * 2025-06-06     Baekgwa               Initial creation
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
 	private final CategoryRepository categoryRepository;
 	private final PostRepository postRepository;
 
+	@CacheEvict(cacheNames = CacheType.CacheNames.CATEGORY_LIST, allEntries = true)
 	@Transactional
 	public void create(CategoryRequest.CreateCategory createCategory) {
-		// 1. 중복 검증
 		if (categoryRepository.existsByName(createCategory.getName())) {
 			throw new GlobalException(ErrorCode.DUPLICATION_CATEGORY);
 		}
 
-		// 2. Entity 생성 및 저장
 		CategoryEntity categoryEntity = CategoryEntity.of(createCategory.getName());
 		categoryRepository.save(categoryEntity);
 	}
 
+	@Cacheable(
+		cacheNames = CacheType.CacheNames.CATEGORY_LIST,
+		key = "@cacheKeyFactory.getCategoryListKey()",
+		unless = "#result == null"
+	)
 	@Transactional(readOnly = true)
 	public List<CategoryResponse.CategoryList> getCategoryList() {
-
+		log.debug("[Cache Miss] Get Category List");
 		List<CategoryPostCount> findCategoryList = categoryRepository.findAllWithPostCount();
-
-		// 2. 응답 객체 변환 후, return
 		return CategoryResponse.CategoryList.from(findCategoryList);
 	}
 
+	@CacheEvict(cacheNames = CacheType.CacheNames.CATEGORY_LIST, allEntries = true)
 	@Transactional
 	public void deleteCategory(String categoryName) {
-		// 1. Category Entity 조회
 		CategoryEntity findCategory = categoryRepository.findByName(categoryName)
 			.orElseThrow(() -> new GlobalException(ErrorCode.NOT_EXIST_CATEGORY));
 
-		// 2. 해당 카테고리로 연결된 글이 있는지 확인
-		//		연결된 글이 있으면, 삭제 불가능.
 		if (postRepository.existsByCategory(findCategory)) {
 			throw new GlobalException(ErrorCode.REGISTERED_CATEGORY_POST);
 		}
 
-		// 3. entity 삭제
 		categoryRepository.delete(findCategory);
 	}
 }

--- a/src/main/java/baekgwa/blogserver/domain/post/controller/PostController.java
+++ b/src/main/java/baekgwa/blogserver/domain/post/controller/PostController.java
@@ -75,12 +75,12 @@ public class PostController {
 		return BaseResponse.success(SuccessCode.REQUEST_SUCCESS, response);
 	}
 
-	@DeleteMapping("/{postId}")
+	@DeleteMapping("/{slug}")
 	@Operation(summary = "포스트 글 삭제")
 	public BaseResponse<Void> deletePost(
-		@PathVariable(value = "postId", required = true) final Long postId
+		@PathVariable(value = "slug", required = true) final String slug
 	) {
-		postService.deletePost(postId);
+		postService.deletePost(slug);
 		return BaseResponse.success(SuccessCode.DELETE_POST_SUCCESS);
 	}
 }

--- a/src/main/java/baekgwa/blogserver/domain/post/dto/PostResponse.java
+++ b/src/main/java/baekgwa/blogserver/domain/post/dto/PostResponse.java
@@ -39,6 +39,7 @@ public class PostResponse {
 	}
 
 	@Getter
+	@Jacksonized
 	@Builder(access = AccessLevel.PROTECTED)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class GetPostDetailResponse {

--- a/src/main/java/baekgwa/blogserver/domain/post/dto/PostResponse.java
+++ b/src/main/java/baekgwa/blogserver/domain/post/dto/PostResponse.java
@@ -79,12 +79,12 @@ public class PostResponse {
 		private final String thumbnailImage;
 		private final String slug;
 		private final Integer viewCount;
-		private List<String> tagList; // final 제거 (나중에 주입)
+		private List<String> tagList;
 		private final String category;
 		private final LocalDateTime createdAt;
 		private final LocalDateTime modifiedAt;
 
-		@QueryProjection // Q클래스 생성을 위해 추가
+		@QueryProjection
 		public GetPostResponse(Long id, String title, String description, String thumbnailImage,
 			String slug, Integer viewCount, String category,
 			LocalDateTime createdAt, LocalDateTime modifiedAt) {

--- a/src/main/java/baekgwa/blogserver/domain/post/dto/PostResponse.java
+++ b/src/main/java/baekgwa/blogserver/domain/post/dto/PostResponse.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * PackageName : baekgwa.blogserver.domain.post.dto
@@ -72,6 +73,9 @@ public class PostResponse {
 	}
 
 	@Getter
+	@Jacksonized
+	@Builder(access = AccessLevel.PROTECTED)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class GetPostResponse {
 		private final Long id;
 		private final String title;

--- a/src/main/java/baekgwa/blogserver/domain/post/service/PostService.java
+++ b/src/main/java/baekgwa/blogserver/domain/post/service/PostService.java
@@ -7,6 +7,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -96,19 +97,23 @@ public class PostService {
 		return PostResponse.CreatePostResponse.from(generatedSlug);
 	}
 
+	@Cacheable(
+		cacheNames = CacheType.CacheNames.POST_DETAIL,
+		key = "@cacheKeyFactory.getPostDetailKey(#slug)",
+		unless = "#result == null"
+	)
 	@Transactional(readOnly = true)
 	public PostResponse.GetPostDetailResponse getPostDetail(String slug, String remoteAddr) {
-		// 1. 포스팅 글 조회
-		PostEntity postEntity = postRepository.findBySlug(slug).orElseThrow(
+		log.debug("[Cache Miss] Get Post Detail, slug:{}", slug);
+
+		PostEntity postEntity = postRepository.findWithCategoryBySlug(slug).orElseThrow(
 			() -> new GlobalException(ErrorCode.NOT_EXIST_POST));
 
-		// 2. 태그 이름 목록 조회
 		List<String> findTagNameList = postTagRepository.findAllByPost(postEntity)
 			.stream()
 			.map(tag -> tag.getTag().getName())
 			.toList();
 
-		// 3. viewCount 증가
 		eventPublisher.publishEvent(new PostViewEvent(postEntity.getId(), remoteAddr));
 
 		return PostResponse.GetPostDetailResponse.of(postEntity, findTagNameList);
@@ -147,16 +152,21 @@ public class PostService {
 		return PageResponse.of(findData);
 	}
 
-	@CacheEvict(cacheNames = CacheType.CacheNames.POST_LIST, allEntries = true)
-	@Transactional
-	public void deletePost(Long postId) {
-		if (!postRepository.existsById(postId)) {
-			throw new GlobalException(ErrorCode.NOT_EXIST_POST);
+	@Caching(
+		evict = {
+			@CacheEvict(cacheNames = CacheType.CacheNames.POST_LIST, allEntries = true),
+			@CacheEvict(cacheNames = CacheType.CacheNames.POST_DETAIL, key = "@cacheKeyFactory.getPostDetailKey(#slug)")
 		}
-		postRepository.deleteById(postId);
+	)
+	@Transactional
+	public void deletePost(String slug) {
+		PostEntity findPost = postRepository.findBySlug(slug)
+			.orElseThrow(() -> new GlobalException(ErrorCode.NOT_EXIST_POST));
+
+		postRepository.deleteBySlug(slug);
 
 		// delete post embedding event 발행
-		eventPublisher.publishEvent(new EmbeddingDeletePostEvent(postId));
+		eventPublisher.publishEvent(new EmbeddingDeletePostEvent(findPost.getId()));
 	}
 
 	private String extractThumbnailByContent(@NonNull String content) {

--- a/src/main/java/baekgwa/blogserver/domain/post/service/PostService.java
+++ b/src/main/java/baekgwa/blogserver/domain/post/service/PostService.java
@@ -20,6 +20,7 @@ import org.springframework.util.StringUtils;
 import baekgwa.blogserver.domain.post.dto.PostRequest;
 import baekgwa.blogserver.domain.post.dto.PostResponse;
 import baekgwa.blogserver.domain.post.type.PostListSort;
+import baekgwa.blogserver.domain.stack.service.StackCacheService;
 import baekgwa.blogserver.global.cache.CacheType;
 import baekgwa.blogserver.global.exception.GlobalException;
 import baekgwa.blogserver.global.response.ErrorCode;
@@ -34,6 +35,7 @@ import baekgwa.blogserver.model.post.post.entity.PostEntity;
 import baekgwa.blogserver.model.post.post.repository.PostRepository;
 import baekgwa.blogserver.model.post.tag.entity.PostTagEntity;
 import baekgwa.blogserver.model.post.tag.repository.PostTagRepository;
+import baekgwa.blogserver.model.stack.post.repository.StackPostRepository;
 import baekgwa.blogserver.model.tag.entity.TagEntity;
 import baekgwa.blogserver.model.tag.repository.TagRepository;
 import lombok.NonNull;
@@ -56,8 +58,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PostService {
 
+	private final StackCacheService stackCacheService;
+
 	private final PostRepository postRepository;
 	private final PostTagRepository postTagRepository;
+	private final StackPostRepository stackPostRepository;
 	private final TagRepository tagRepository;
 	private final CategoryRepository categoryRepository;
 
@@ -168,6 +173,11 @@ public class PostService {
 	public void deletePost(String slug) {
 		PostEntity findPost = postRepository.findBySlug(slug)
 			.orElseThrow(() -> new GlobalException(ErrorCode.NOT_EXIST_POST));
+
+		Long stackId = stackPostRepository.findStackIdByPostId(findPost.getId()).orElse(null);
+		if (stackId != null) {
+			stackCacheService.deleteStackPostLink(stackId, findPost.getId());
+		}
 
 		postRepository.deleteBySlug(slug);
 

--- a/src/main/java/baekgwa/blogserver/domain/post/service/PostService.java
+++ b/src/main/java/baekgwa/blogserver/domain/post/service/PostService.java
@@ -63,7 +63,12 @@ public class PostService {
 
 	private final ApplicationEventPublisher eventPublisher;
 
-	@CacheEvict(cacheNames = CacheType.CacheNames.POST_LIST, allEntries = true)
+	@Caching(
+		evict = {
+			@CacheEvict(cacheNames = CacheType.CacheNames.POST_LIST, allEntries = true),
+			@CacheEvict(cacheNames = CacheType.CacheNames.CATEGORY_LIST, allEntries = true)
+		}
+	)
 	@Transactional
 	public PostResponse.CreatePostResponse create(PostRequest.CreatePost request) {
 		if (postRepository.existsByTitle(request.getTitle())) {
@@ -155,7 +160,8 @@ public class PostService {
 	@Caching(
 		evict = {
 			@CacheEvict(cacheNames = CacheType.CacheNames.POST_LIST, allEntries = true),
-			@CacheEvict(cacheNames = CacheType.CacheNames.POST_DETAIL, key = "@cacheKeyFactory.getPostDetailKey(#slug)")
+			@CacheEvict(cacheNames = CacheType.CacheNames.POST_DETAIL, key = "@cacheKeyFactory.getPostDetailKey(#slug)"),
+			@CacheEvict(cacheNames = CacheType.CacheNames.CATEGORY_LIST, allEntries = true)
 		}
 	)
 	@Transactional

--- a/src/main/java/baekgwa/blogserver/domain/post/service/PostService.java
+++ b/src/main/java/baekgwa/blogserver/domain/post/service/PostService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -61,47 +62,37 @@ public class PostService {
 
 	private final ApplicationEventPublisher eventPublisher;
 
+	@CacheEvict(cacheNames = CacheType.CacheNames.POST_LIST, allEntries = true)
 	@Transactional
 	public PostResponse.CreatePostResponse create(PostRequest.CreatePost request) {
-		// 1. 제목 중복 검증 -> 슬러그로 활용됨
 		if (postRepository.existsByTitle(request.getTitle())) {
 			throw new GlobalException(ErrorCode.DUPLICATION_POST_TITLE);
 		}
 
-		// 2. category 유효성 검증 및 Entity 조회
 		CategoryEntity findCategory = categoryRepository.findById(request.getCategoryId()).orElseThrow(
 			() -> new GlobalException(ErrorCode.NOT_EXIST_CATEGORY));
 
-		// 3. tagList 유효성 검증
 		List<TagEntity> findTagEntityList = tagRepository.findAllById(request.getTagIdList());
 		if (findTagEntityList.size() != request.getTagIdList().size()) {
 			throw new GlobalException(ErrorCode.NOT_EXIST_TAG_LIST);
 		}
 
-		// 4. 썸네일 추출
 		if (!StringUtils.hasText(request.getThumbnailImage())) {
-			// 4-1. 썸네일 이미지 추출
 			String thumbnailImage = extractThumbnailByContent(request.getContent());
-			// 4-2. 새로운 request 불변 객체 생성
 			request = request.withThumbnailImage(thumbnailImage);
 		}
 
-		// 5. 슬러그 생성 (제목으로 슬러그 생성)
 		String generatedSlug = SlugUtil.generateSlug(request.getTitle());
 
-		// 6. 포스트(카테고리 포함) 생성 / 저장
 		PostEntity newPost = PostEntity.of(request.getTitle(), request.getContent(), request.getDescription(),
 			request.getThumbnailImage(), generatedSlug, findCategory);
 		postRepository.save(newPost);
 
-		// 7. 포스팅 태그 생성 / 저장
 		List<PostTagEntity> newPostTag = findTagEntityList.stream().map(tag -> PostTagEntity.of(newPost, tag)).toList();
 		postTagRepository.saveAll(newPostTag);
 
-		// 8. post embedding event 발행
 		eventPublisher.publishEvent(new EmbeddingCreatePostEvent(newPost, findTagEntityList));
 
-		// 9. 응답 생성. 리다이렉션용 slug 주소
 		return PostResponse.CreatePostResponse.from(generatedSlug);
 	}
 
@@ -125,7 +116,8 @@ public class PostService {
 
 	@Cacheable(
 		cacheNames = CacheType.CacheNames.POST_LIST,
-		key = "@cacheKeyFactory.getPostListKey(#keyword, #category, #page, #size, #sort)",
+		key = "@cacheKeyFactory.getPostListKey(#category, #page, #size, #sort)",
+		condition = "#keyword == null || #keyword.isEmpty()",
 		unless = "#result == null"
 	)
 	@Transactional(readOnly = true)
@@ -155,6 +147,7 @@ public class PostService {
 		return PageResponse.of(findData);
 	}
 
+	@CacheEvict(cacheNames = CacheType.CacheNames.POST_LIST, allEntries = true)
 	@Transactional
 	public void deletePost(Long postId) {
 		if (!postRepository.existsById(postId)) {

--- a/src/main/java/baekgwa/blogserver/domain/post/service/PostService.java
+++ b/src/main/java/baekgwa/blogserver/domain/post/service/PostService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -17,6 +18,7 @@ import org.springframework.util.StringUtils;
 import baekgwa.blogserver.domain.post.dto.PostRequest;
 import baekgwa.blogserver.domain.post.dto.PostResponse;
 import baekgwa.blogserver.domain.post.type.PostListSort;
+import baekgwa.blogserver.global.cache.CacheType;
 import baekgwa.blogserver.global.exception.GlobalException;
 import baekgwa.blogserver.global.response.ErrorCode;
 import baekgwa.blogserver.global.response.PageResponse;
@@ -121,24 +123,32 @@ public class PostService {
 		return PostResponse.GetPostDetailResponse.of(postEntity, findTagNameList);
 	}
 
+	@Cacheable(
+		cacheNames = CacheType.CacheNames.POST_LIST,
+		key = "@cacheKeyFactory.getPostListKey(#keyword, #category, #page, #size, #sort)",
+		unless = "#result == null"
+	)
 	@Transactional(readOnly = true)
 	public PageResponse<PostResponse.GetPostResponse> getPostList(
-		@Nullable String keyword, int page, int size, @Nullable String category, PostListSort sort
+		@Nullable String keyword,
+		int page,
+		int size,
+		@Nullable String category,
+		PostListSort sort
 	) {
-		// 1. 페이지네이션 파라미터 유효성 검증
+		log.debug("[Cache Miss] Get Post List, keyword:{}, page:{}, size:{}, category:{}, sort:{}",
+			keyword, page, size, category, sort
+		);
+
 		if (page < 0 || size < 1) {
 			throw new GlobalException(ErrorCode.INVALID_PAGINATION_PARAMETER);
 		}
 
-		// 1-1. pageRequest 생성
 		Pageable pageable = PageRequest.of(page, size);
-
-		// 2. category 유효성 검증
 		if (StringUtils.hasText(category) && !categoryRepository.existsByName(category)) {
 			throw new GlobalException(ErrorCode.NOT_EXIST_CATEGORY);
 		}
 
-		// 3. Entity 조회
 		Page<PostResponse.GetPostResponse> findData =
 			postRepository.searchPostList(keyword, category, pageable, sort);
 

--- a/src/main/java/baekgwa/blogserver/domain/stack/dto/StackResponse.java
+++ b/src/main/java/baekgwa/blogserver/domain/stack/dto/StackResponse.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * PackageName : baekgwa.blogserver.domain.stack.dto
@@ -84,6 +85,7 @@ public class StackResponse {
 	}
 
 	@Getter
+	@Jacksonized
 	@Builder(access = AccessLevel.PROTECTED)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class StackInfo {
@@ -152,6 +154,7 @@ public class StackResponse {
 	}
 
 	@Getter
+	@Jacksonized
 	@Builder(access = AccessLevel.PROTECTED)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class StackPostInfo {

--- a/src/main/java/baekgwa/blogserver/domain/stack/service/StackCacheService.java
+++ b/src/main/java/baekgwa/blogserver/domain/stack/service/StackCacheService.java
@@ -1,0 +1,73 @@
+package baekgwa.blogserver.domain.stack.service;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import baekgwa.blogserver.domain.stack.dto.StackResponse;
+import baekgwa.blogserver.global.cache.CacheType;
+import baekgwa.blogserver.model.stack.post.entity.StackPostEntity;
+import baekgwa.blogserver.model.stack.post.repository.StackPostRepository;
+import baekgwa.blogserver.model.stack.stack.entity.StackEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * PackageName : baekgwa.blogserver.domain.stack.service
+ * FileName    : StackCacheService
+ * Author      : Baekgwa
+ * Date        : 26. 1. 25.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 26. 1. 25.     Baekgwa               Initial creation
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StackCacheService {
+
+	private final StackPostRepository stackPostRepository;
+
+	@Cacheable(
+		cacheNames = CacheType.CacheNames.STACK_RELATIVE_POST_LIST,
+		key = "@cacheKeyFactory.getRelativeStackPostListKey(#findStack.getId)",
+		unless = "#result == null"
+	)
+	@Transactional(readOnly = true)
+	public StackResponse.StackInfo getRelativeStackPostList(StackEntity findStack) {
+		log.debug("[Cache Miss] Get Relative Stack Post, stack Title:{}, stack id:{}", findStack.getTitle(), findStack.getId());
+
+		List<StackPostEntity> findStackPostList = stackPostRepository.findAllByStack(findStack);
+
+		List<StackResponse.StackPostInfo> stackPostInfoList = findStackPostList.stream()
+			.map(StackResponse.StackPostInfo::of)
+			.sorted(Comparator.comparing(StackResponse.StackPostInfo::getSequence))
+			.toList();
+
+		return StackResponse.StackInfo.of(findStack, stackPostInfoList);
+	}
+
+	@Transactional
+	@CacheEvict(
+		cacheNames = CacheType.CacheNames.STACK_RELATIVE_POST_LIST,
+		key = "@cacheKeyFactory.getRelativeStackPostListKey(#stackId)"
+	)
+	public void deleteStackPostLink(Long stackId, Long postId) {
+		log.info("Evict Stack Cache & Delete Link -> stackId: {}, postId: {}", stackId, postId);
+		stackPostRepository.deleteByStackIdAndPostId(stackId, postId);
+	}
+
+	@CacheEvict(
+		cacheNames = CacheType.CacheNames.STACK_RELATIVE_POST_LIST,
+		key = "@cacheKeyFactory.getRelativeStackPostListKey(#stackId)"
+	)
+	public void evictRelativeStackPostList(Long stackId) {
+		log.info("Evict Stack Cache stackId: {}", stackId);
+	}
+}

--- a/src/main/java/baekgwa/blogserver/domain/stack/service/StackService.java
+++ b/src/main/java/baekgwa/blogserver/domain/stack/service/StackService.java
@@ -39,10 +39,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class StackService {
 
+	private final StackCacheService stackCacheService;
+
 	private final StackRepository stackRepository;
 	private final StackPostRepository stackPostRepository;
 	private final CategoryRepository categoryRepository;
 	private final PostRepository postRepository;
+
 
 	@Transactional
 	public StackResponse.CreateNewStack createNewStackSeries(StackRequest.NewStackSeries request) {
@@ -90,41 +93,14 @@ public class StackService {
 		return new StackResponse.CreateNewStack(savedStackSeries.getId());
 	}
 
-	private void validateCheckStackPostSequence(List<StackRequest.StackPost> stackPostList) {
-		// 1. Sequence 값들을 추출하여 리스트로 만듦
-		List<Long> sequenceList = stackPostList.stream()
-			.map(StackRequest.StackPost::getSequence)
-			.sorted()
-			.toList();
-
-		// 2. 중복된 Sequence 값이 있는지 확인
-		long distinctCount = sequenceList.stream().distinct().count();
-		if (distinctCount != sequenceList.size()) {
-			throw new GlobalException(ErrorCode.INVALID_STACK_POST_SEQUENCE);
-		}
-
-		// 3. 1부터 시작하여 연속적인 값인지 확인
-		for (int i = 0; i < sequenceList.size(); i++) {
-			if (sequenceList.get(i) != i + 1) {
-				throw new GlobalException(ErrorCode.INVALID_STACK_POST_SEQUENCE);
-			}
-		}
-	}
-
 	@Transactional(readOnly = true)
 	public StackResponse.StackInfo getRelativeStackPostInfo(Long postId) {
 		Optional<StackPostEntity> opFindStackPost = stackPostRepository.findByPostIdWithStack(postId);
 		if(opFindStackPost.isEmpty()) return null;
 
 		StackEntity findStack = opFindStackPost.get().getStack();
-		List<StackPostEntity> findStackPostList = stackPostRepository.findAllByStack(findStack);
 
-		List<StackResponse.StackPostInfo> stackPostInfoList = findStackPostList.stream()
-			.map(StackResponse.StackPostInfo::of)
-			.sorted(Comparator.comparing(StackResponse.StackPostInfo::getSequence))
-			.toList();
-
-		return StackResponse.StackInfo.of(findStack, stackPostInfoList);
+		return stackCacheService.getRelativeStackPostList(findStack);
 	}
 
 	@Transactional(readOnly = true)
@@ -157,32 +133,25 @@ public class StackService {
 
 	@Transactional
 	public StackResponse.ModifyStack modifyStackSeries(Long stackId, StackRequest.ModifyStackSeries request) {
-		// 1. 스택 정보 조회
 		StackEntity findStack = stackRepository.findById(stackId).orElseThrow(
 			() -> new GlobalException(ErrorCode.NOTFOUND_STACK));
 
-		// 2. 스택 정보 수정
 		findStack.modifyStack(request.getTitle(), request.getDescription(), request.getThumbnailImage());
 
-		// 3. 포스트 글 관련 내용 유효성 검증
 		validateCheckStackPostSequence(request.getStackPostList());
 
-		// 4. 기존 연관된 포스트 글 모두 삭제
 		stackPostRepository.deleteAllByStack(findStack);
 
-		// 5. 해당 포스트 들이 이미, 시리즈에 할당되어있는지 검증.
 		List<Long> postIdList = request.getStackPostList().stream().map(StackRequest.StackPost::getPostId).toList();
 		if (stackPostRepository.existsByPostIdIn(postIdList)) {
 			throw new GlobalException(ErrorCode.ALREADY_REGISTER_POST_STACK_SERIES);
 		}
 
-		// 6. 포스팅 글 조회 및 유효성 검사
 		List<PostEntity> findPostEntity = postRepository.findAllById(postIdList);
 		if (findPostEntity.size() != postIdList.size()) {
 			throw new GlobalException(ErrorCode.INVALID_POST_LIST);
 		}
 
-		// 7. 포스팅 글, 스택에 등록
 		Map<Long, Long> postSequenceMap = request.getStackPostList()
 			.stream()
 			.collect(Collectors.toMap(StackRequest.StackPost::getPostId, StackRequest.StackPost::getSequence));
@@ -191,6 +160,8 @@ public class StackService {
 			.map(post -> StackPostEntity.of(findStack, post, postSequenceMap.get(post.getId())))
 			.toList();
 		stackPostRepository.saveAll(newStackPost);
+
+		stackCacheService.evictRelativeStackPostList(findStack.getId());
 
 		return new StackResponse.ModifyStack(findStack.getId());
 	}
@@ -208,5 +179,26 @@ public class StackService {
 
 		// 3. dto return
 		return StackResponse.ModifyStackInfo.of(findStack, modifyStackpostInfoList);
+	}
+
+	private void validateCheckStackPostSequence(List<StackRequest.StackPost> stackPostList) {
+		// 1. Sequence 값들을 추출하여 리스트로 만듦
+		List<Long> sequenceList = stackPostList.stream()
+			.map(StackRequest.StackPost::getSequence)
+			.sorted()
+			.toList();
+
+		// 2. 중복된 Sequence 값이 있는지 확인
+		long distinctCount = sequenceList.stream().distinct().count();
+		if (distinctCount != sequenceList.size()) {
+			throw new GlobalException(ErrorCode.INVALID_STACK_POST_SEQUENCE);
+		}
+
+		// 3. 1부터 시작하여 연속적인 값인지 확인
+		for (int i = 0; i < sequenceList.size(); i++) {
+			if (sequenceList.get(i) != i + 1) {
+				throw new GlobalException(ErrorCode.INVALID_STACK_POST_SEQUENCE);
+			}
+		}
 	}
 }

--- a/src/main/java/baekgwa/blogserver/global/cache/CacheKeyFactory.java
+++ b/src/main/java/baekgwa/blogserver/global/cache/CacheKeyFactory.java
@@ -50,4 +50,11 @@ public final class CacheKeyFactory {
 	public String getCategoryListKey() {
 		return ALL;
 	}
+
+	/**
+	 * Stack Post 연관글 조회용 캐시 키
+	 */
+	public String getRelativeStackPostListKey(Long stackId) {
+		return String.format("stack:%s", stackId);
+	}
 }

--- a/src/main/java/baekgwa/blogserver/global/cache/CacheKeyFactory.java
+++ b/src/main/java/baekgwa/blogserver/global/cache/CacheKeyFactory.java
@@ -1,0 +1,39 @@
+package baekgwa.blogserver.global.cache;
+
+import org.springframework.stereotype.Component;
+
+import baekgwa.blogserver.domain.post.type.PostListSort;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * PackageName : baekgwa.blogserver.global.cache
+ * FileName    : CacheKeyFactory
+ * Author      : Baekgwa
+ * Date        : 26. 1. 24.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 26. 1. 24.     Baekgwa               Initial creation
+ */
+@Component("cacheKeyFactory")
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CacheKeyFactory {
+
+	private static final String NONE = "none";
+	private static final String ALL = "all";
+
+	/**
+	 * 메인페이지 에서, 글 목록 캐싱을 위한 캐시 키
+	 */
+	public String getPostListKey(String keyword, String category, int page, int size, PostListSort sort) {
+		return String.format("keyword:%s:category:%s:page:%d:size:%d:sort:%s",
+			keyword != null ? keyword : NONE,
+			category != null ? category : ALL,
+			page,
+			size,
+			sort
+		);
+	}
+}

--- a/src/main/java/baekgwa/blogserver/global/cache/CacheKeyFactory.java
+++ b/src/main/java/baekgwa/blogserver/global/cache/CacheKeyFactory.java
@@ -36,4 +36,11 @@ public final class CacheKeyFactory {
 			Objects.requireNonNullElse(sort, PostListSort.LATEST)
 		);
 	}
+
+	/**
+	 * 게시글 상세 조회 시, 캐싱을 위한 키
+	 */
+	public String getPostDetailKey(String slug) {
+		return String.format("slug:%s", slug);
+	}
 }

--- a/src/main/java/baekgwa/blogserver/global/cache/CacheKeyFactory.java
+++ b/src/main/java/baekgwa/blogserver/global/cache/CacheKeyFactory.java
@@ -1,5 +1,7 @@
 package baekgwa.blogserver.global.cache;
 
+import java.util.Objects;
+
 import org.springframework.stereotype.Component;
 
 import baekgwa.blogserver.domain.post.type.PostListSort;
@@ -21,19 +23,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CacheKeyFactory {
 
-	private static final String NONE = "none";
 	private static final String ALL = "all";
 
 	/**
 	 * 메인페이지 에서, 글 목록 캐싱을 위한 캐시 키
 	 */
-	public String getPostListKey(String keyword, String category, int page, int size, PostListSort sort) {
-		return String.format("keyword:%s:category:%s:page:%d:size:%d:sort:%s",
-			keyword != null ? keyword : NONE,
-			category != null ? category : ALL,
+	public String getPostListKey(String category, int page, int size, PostListSort sort) {
+		return String.format("category:%s:page:%d:size:%d:sort:%s",
+			Objects.requireNonNullElse(category, ALL),
 			page,
 			size,
-			sort
+			Objects.requireNonNullElse(sort, PostListSort.LATEST)
 		);
 	}
 }

--- a/src/main/java/baekgwa/blogserver/global/cache/CacheKeyFactory.java
+++ b/src/main/java/baekgwa/blogserver/global/cache/CacheKeyFactory.java
@@ -43,4 +43,11 @@ public final class CacheKeyFactory {
 	public String getPostDetailKey(String slug) {
 		return String.format("slug:%s", slug);
 	}
+
+	/**
+	 * 전체 카테고리 조회용 캐시 키
+	 */
+	public String getCategoryListKey() {
+		return ALL;
+	}
 }

--- a/src/main/java/baekgwa/blogserver/global/cache/CacheType.java
+++ b/src/main/java/baekgwa/blogserver/global/cache/CacheType.java
@@ -1,0 +1,30 @@
+package baekgwa.blogserver.global.cache;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.UtilityClass;
+
+/**
+ * PackageName : baekgwa.blogserver.global.cache
+ * FileName    : CacheType
+ * Author      : Baekgwa
+ * Date        : 26. 1. 24.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 26. 1. 24.     Baekgwa               Initial creation
+ */
+@Getter
+@AllArgsConstructor
+public enum CacheType {
+	POST_LIST(CacheNames.POST_LIST, 60 * 24); // 1일, 1440분
+
+	private final String cacheName;
+	private final int ttlMinutes;
+
+	@UtilityClass
+	public static class CacheNames {
+		public static final String POST_LIST = "posts:list";
+	}
+}

--- a/src/main/java/baekgwa/blogserver/global/cache/CacheType.java
+++ b/src/main/java/baekgwa/blogserver/global/cache/CacheType.java
@@ -18,7 +18,8 @@ import lombok.experimental.UtilityClass;
 @Getter
 @AllArgsConstructor
 public enum CacheType {
-	POST_LIST(CacheNames.POST_LIST, 60 * 24); // 1일, 1440분
+	POST_LIST(CacheNames.POST_LIST, 60 * 24), // 1일, 1440분
+	POST_DETAIL(CacheNames.POST_DETAIL, 60 * 24);
 
 	private final String cacheName;
 	private final int ttlMinutes;
@@ -26,5 +27,6 @@ public enum CacheType {
 	@UtilityClass
 	public static class CacheNames {
 		public static final String POST_LIST = "posts:list";
+		public static final String POST_DETAIL = "posts:detail";
 	}
 }

--- a/src/main/java/baekgwa/blogserver/global/cache/CacheType.java
+++ b/src/main/java/baekgwa/blogserver/global/cache/CacheType.java
@@ -20,7 +20,8 @@ import lombok.experimental.UtilityClass;
 public enum CacheType {
 	POST_LIST(CacheNames.POST_LIST, 60 * 24), // 1일, 1440분
 	POST_DETAIL(CacheNames.POST_DETAIL, 60 * 24),
-	CATEGORY_LIST(CacheNames.CATEGORY_LIST, 60 * 24),;
+	CATEGORY_LIST(CacheNames.CATEGORY_LIST, 60 * 24),
+	STACK_RELATIVE_POST_LIST(CacheNames.STACK_RELATIVE_POST_LIST, 60 * 24);
 
 	private final String cacheName;
 	private final int ttlMinutes;
@@ -29,6 +30,9 @@ public enum CacheType {
 	public static class CacheNames {
 		public static final String POST_LIST = "posts:list";
 		public static final String POST_DETAIL = "posts:detail";
+
 		public static final String CATEGORY_LIST = "categories:list";
+
+		public static final String STACK_RELATIVE_POST_LIST = "stacks:post:relative:list";
 	}
 }

--- a/src/main/java/baekgwa/blogserver/global/cache/CacheType.java
+++ b/src/main/java/baekgwa/blogserver/global/cache/CacheType.java
@@ -19,7 +19,8 @@ import lombok.experimental.UtilityClass;
 @AllArgsConstructor
 public enum CacheType {
 	POST_LIST(CacheNames.POST_LIST, 60 * 24), // 1일, 1440분
-	POST_DETAIL(CacheNames.POST_DETAIL, 60 * 24);
+	POST_DETAIL(CacheNames.POST_DETAIL, 60 * 24),
+	CATEGORY_LIST(CacheNames.CATEGORY_LIST, 60 * 24),;
 
 	private final String cacheName;
 	private final int ttlMinutes;
@@ -28,5 +29,6 @@ public enum CacheType {
 	public static class CacheNames {
 		public static final String POST_LIST = "posts:list";
 		public static final String POST_DETAIL = "posts:detail";
+		public static final String CATEGORY_LIST = "categories:list";
 	}
 }

--- a/src/main/java/baekgwa/blogserver/global/cache/RedisCacheConfig.java
+++ b/src/main/java/baekgwa/blogserver/global/cache/RedisCacheConfig.java
@@ -1,0 +1,78 @@
+package baekgwa.blogserver.global.cache;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * PackageName : baekgwa.blogserver.global.cache
+ * FileName    : RedisCacheConfig
+ * Author      : Baekgwa
+ * Date        : 26. 1. 24.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 26. 1. 24.     Baekgwa               Initial creation
+ */
+@Profile("!test")
+@Configuration
+@EnableCaching
+@Slf4j
+public class RedisCacheConfig {
+
+	@Bean
+	public CacheManager cacheManager(
+		RedisConnectionFactory connectionFactory,
+		ObjectMapper rootObjectMapper
+	) {
+		ObjectMapper redisObjectMapper = rootObjectMapper.copy();
+
+		PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+			.allowIfBaseType(Object.class)
+			.build();
+		redisObjectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+
+		RedisCacheConfiguration defaultConf = RedisCacheConfiguration.defaultCacheConfig()
+			.disableCachingNullValues()
+			.entryTtl(Duration.ofMinutes(30)) //default 30분
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
+
+		Map<String, RedisCacheConfiguration> configurations = new HashMap<>();
+		for (CacheType cacheType : CacheType.values()) {
+			log.debug("Creating cache configuration for cache type {}", cacheType);
+			configurations.put(
+				cacheType.getCacheName(),
+				defaultConf.entryTtl(Duration.ofMinutes(cacheType.getTtlMinutes()))
+			);
+		}
+
+		return RedisCacheManager.RedisCacheManagerBuilder
+			.fromConnectionFactory(connectionFactory)
+			.cacheDefaults(defaultConf)
+			.withInitialCacheConfigurations(configurations)
+			.build();
+	}
+}

--- a/src/main/java/baekgwa/blogserver/global/cache/RedisCacheConfig.java
+++ b/src/main/java/baekgwa/blogserver/global/cache/RedisCacheConfig.java
@@ -18,8 +18,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -42,17 +44,27 @@ public class RedisCacheConfig {
 
 	@Bean
 	public CacheManager cacheManager(
-		RedisConnectionFactory connectionFactory,
-		ObjectMapper rootObjectMapper
+		RedisConnectionFactory connectionFactory
 	) {
-		ObjectMapper redisObjectMapper = rootObjectMapper.copy();
+		ObjectMapper redisObjectMapper = new ObjectMapper();
+
+		redisObjectMapper.registerModule(new JavaTimeModule());
+		redisObjectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
 		PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
-			.allowIfBaseType(Object.class)
+			.allowIfSubType("baekgwa.blogserver")
+			.allowIfSubType("java.util")
+			.allowIfSubType("java.time")
 			.build();
-		redisObjectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
 
-		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+		redisObjectMapper.activateDefaultTyping(
+			ptv,
+			ObjectMapper.DefaultTyping.NON_FINAL,
+			JsonTypeInfo.As.PROPERTY
+		);
+
+		GenericJackson2JsonRedisSerializer serializer =
+			new GenericJackson2JsonRedisSerializer(redisObjectMapper);
 
 		RedisCacheConfiguration defaultConf = RedisCacheConfiguration.defaultCacheConfig()
 			.disableCachingNullValues()

--- a/src/main/java/baekgwa/blogserver/global/config/ElasticsearchConfig.java
+++ b/src/main/java/baekgwa/blogserver/global/config/ElasticsearchConfig.java
@@ -78,10 +78,9 @@ public class ElasticsearchConfig {
 				log.debug("Elasticsearch index [{}] already exists.", indexName);
 				return;
 			}
-		} catch (ResponseException e) {
-			if (e.getResponse().getStatusLine().getStatusCode() != 404) {
-				throw e;
-			}
+		} catch (Exception e) {
+			log.error("Elasticsearch connection failed. Skipping index creation.", e);
+			return;
 		}
 
 		log.info("Creating Elasticsearch index [{}] with custom settings...", indexName);

--- a/src/main/java/baekgwa/blogserver/global/response/PageResponse.java
+++ b/src/main/java/baekgwa/blogserver/global/response/PageResponse.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * PackageName : baekgwa.blogserver.global.response
@@ -21,7 +22,8 @@ import lombok.RequiredArgsConstructor;
  * 2025-05-30     Baekgwa               Initial creation
  */
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Jacksonized
+@Builder(access = AccessLevel.PROTECTED)
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class PageResponse<T> {
 	private final List<T> content;
@@ -29,8 +31,8 @@ public class PageResponse<T> {
 	private final int pageSize;
 	private final long totalElements;
 	private final int totalPages;
-	private final boolean isLast;
-	private final boolean isFirst;
+	private final boolean last;
+	private final boolean first;
 	private final boolean hasNext;
 	private final boolean hasPrevious;
 
@@ -42,11 +44,10 @@ public class PageResponse<T> {
 			.pageSize(page.getSize())
 			.totalElements(page.getTotalElements())
 			.totalPages(page.getTotalPages())
-			.isLast(page.isLast())
-			.isFirst(page.isFirst())
+			.last(page.isLast())
+			.first(page.isFirst())
 			.hasNext(page.hasNext())
 			.hasPrevious(page.hasPrevious())
 			.build();
 	}
 }
-

--- a/src/main/java/baekgwa/blogserver/model/post/post/repository/PostRepository.java
+++ b/src/main/java/baekgwa/blogserver/model/post/post/repository/PostRepository.java
@@ -25,5 +25,9 @@ public interface PostRepository extends JpaRepository<PostEntity, Long>, PostRep
 	boolean existsByCategory(CategoryEntity category);
 
 	@EntityGraph(attributePaths = {"category"})
+	Optional<PostEntity> findWithCategoryBySlug(String slug);
+
 	Optional<PostEntity> findBySlug(String slug);
+
+	void deleteBySlug(String slug);
 }

--- a/src/main/java/baekgwa/blogserver/model/stack/post/repository/StackPostRepository.java
+++ b/src/main/java/baekgwa/blogserver/model/stack/post/repository/StackPostRepository.java
@@ -33,4 +33,9 @@ public interface StackPostRepository extends JpaRepository<StackPostEntity, Long
 	boolean existsByPostIdIn(@Param("postIdList") List<Long> postIdList);
 
 	void deleteAllByStack(StackEntity stack);
+
+	void deleteByStackIdAndPostId(Long stackId, Long postId);
+
+	@Query("SELECT sp.stack.id FROM StackPostEntity sp WHERE sp.post.id = :postId")
+	Optional<Long> findStackIdByPostId(@Param("postId") Long postId);
 }

--- a/src/test/java/baekgwa/blogserver/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/baekgwa/blogserver/domain/post/controller/PostControllerTest.java
@@ -43,7 +43,8 @@ class PostControllerTest extends SpringBootTestSupporter {
 		CategoryEntity saveCategory = categoryDataFactory.newCategoryList(1).getFirst();
 		List<TagEntity> saveTagList = tagDataFactory.newTagList(5);
 		List<Long> saveTagIdList = saveTagList.stream().map(TagEntity::getId).toList();
-		PostRequest.CreatePost request = PostRequest.CreatePost.of("제목", "내용", "설명", "썸네일url", saveTagIdList, saveCategory.getId());
+		PostRequest.CreatePost request = PostRequest.CreatePost.of("제목", "내용", "설명", "썸네일url", saveTagIdList,
+			saveCategory.getId());
 
 		// when
 		ResultActions perform = mockMvc.perform(post("/post")
@@ -67,7 +68,8 @@ class PostControllerTest extends SpringBootTestSupporter {
 		CategoryEntity saveCategory = categoryDataFactory.newCategoryList(1).getFirst();
 		List<TagEntity> saveTagList = tagDataFactory.newTagList(5);
 		List<Long> saveTagIdList = saveTagList.stream().map(TagEntity::getId).toList();
-		PostRequest.CreatePost request = PostRequest.CreatePost.of("제목", "내용", "설명", "썸네일url", saveTagIdList, saveCategory.getId());
+		PostRequest.CreatePost request = PostRequest.CreatePost.of("제목", "내용", "설명", "썸네일url", saveTagIdList,
+			saveCategory.getId());
 
 		// when
 		ResultActions perform = mockMvc.perform(post("/post/detail")
@@ -175,7 +177,7 @@ class PostControllerTest extends SpringBootTestSupporter {
 		PostEntity savePost = postDataFactory.newPostList(1, saveTagList, saveCategory).getFirst();
 
 		// when
-		ResultActions perform = mockMvc.perform(delete("/post/{postId}", savePost.getId()));
+		ResultActions perform = mockMvc.perform(delete("/post/{slug}", savePost.getSlug()));
 
 		// then
 		perform.andDo(print())

--- a/src/test/java/baekgwa/blogserver/domain/post/service/PostServiceTest.java
+++ b/src/test/java/baekgwa/blogserver/domain/post/service/PostServiceTest.java
@@ -19,6 +19,7 @@ import baekgwa.blogserver.integration.SpringBootTestSupporter;
 import baekgwa.blogserver.model.category.entity.CategoryEntity;
 import baekgwa.blogserver.model.post.post.entity.PostEntity;
 import baekgwa.blogserver.model.post.tag.entity.PostTagEntity;
+import baekgwa.blogserver.model.stack.stack.entity.StackEntity;
 import baekgwa.blogserver.model.tag.entity.TagEntity;
 
 /**
@@ -352,5 +353,23 @@ class PostServiceTest extends SpringBootTestSupporter {
 			.isInstanceOf(GlobalException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.NOT_EXIST_POST);
+	}
+
+	@DisplayName("특정 스택에 포함된 글이라면, 스택 목록에서도 제거 합니다.")
+	@Test
+	void deletePost3() {
+		// given
+		CategoryEntity saveCategory = categoryDataFactory.newCategoryList(1).getFirst();
+		List<TagEntity> saveTagList = tagDataFactory.newTagList(1);
+		PostEntity savePost = postDataFactory.newPostList(1, saveTagList, saveCategory).getFirst();
+		StackEntity saveStack = stackDataFactory.newStack(1L, saveCategory).getFirst();
+		stackDataFactory.newStackPost(saveStack, List.of(savePost));
+
+		// when
+		postService.deletePost(savePost.getSlug());
+
+		// then
+		assertThat(postRepository.findById(savePost.getId())).isEmpty();
+		assertThat(stackPostRepository.findAll()).isEmpty();
 	}
 }

--- a/src/test/java/baekgwa/blogserver/domain/post/service/PostServiceTest.java
+++ b/src/test/java/baekgwa/blogserver/domain/post/service/PostServiceTest.java
@@ -336,7 +336,7 @@ class PostServiceTest extends SpringBootTestSupporter {
 		PostEntity savePost = postDataFactory.newPostList(1, saveTagList, saveCategory).getFirst();
 
 		// when
-		postService.deletePost(savePost.getId());
+		postService.deletePost(savePost.getSlug());
 
 		// then
 		assertThat(postRepository.findById(savePost.getId())).isEmpty();
@@ -348,7 +348,7 @@ class PostServiceTest extends SpringBootTestSupporter {
 		// given
 
 		// when // then
-		assertThatThrownBy(() -> postService.deletePost(1L))
+		assertThatThrownBy(() -> postService.deletePost("NOT-EXIST-SLUG"))
 			.isInstanceOf(GlobalException.class)
 			.extracting("errorCode")
 			.isEqualTo(ErrorCode.NOT_EXIST_POST);


### PR DESCRIPTION
<!-- 제목 : [분류] : 제목 -->
<!-- 분류 = 이슈 분류  -->
## 👇 개요
<!-- 간단한 개요  -->
- #52 

---

## 🔨 작업 내용
- 전반적으로, Annotation 기반의 캐싱 처리로 통합 진행
- 프록시로 사용되어 내부 로직을 일정 부분 실행 후 캐싱 처리가 가능한 부분은 별도의 Service 로 분리하여 진행. (StackCacheService)
  -  프록시로 처리되어, 내부 객체로 처리 불가능.
- [x] 캐싱 처리를 위한 CacheManager Bean 추가 등록
- [x] 주요로 가장 많이 사용되는 조회 API 들 캐싱 처리 추가
  - [x] 글 목록 조회(페이징)
  - [x] 글 상세 조회
  - [x] 카테고리 조회
  - [x] 연관 글 조회
- [x] 기타 EmbeddingStore 최초 연결 시, 없을 경우, Exception 타고 올라가 Application 실행 자체가 실패하는 로직 수정.

---

## 🧪 확인 사항

- [x] 빌드 정상 작동
- [x] 주요 기능 정상 동작
